### PR TITLE
Fix not-found heading text

### DIFF
--- a/src/app/not-found/not-found.component.html
+++ b/src/app/not-found/not-found.component.html
@@ -10,7 +10,7 @@
         </a>
       </header>
       <main class="mb-auto col-12">
-        <h1 class="display-1 fw-bold">Uuuups, something is broken...</h1>
+        <h1 class="display-1 fw-bold">Oops, something is broken...</h1>
         <p class="lead">The page you are looking for doesn't exist or has been moved.</p>
         <a routerLink="/" class="link-fancy">
           <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-left" viewBox="0 0 16 16">


### PR DESCRIPTION
## Summary
- correct the 404 page heading typo

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684931734f04832a8220e0e5995ab26d